### PR TITLE
Add hashed password support

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,5 +1,6 @@
 // server/models/User.js
 const mongoose = require("mongoose");
+const bcrypt = require("bcryptjs");
 
 const UserSchema = new mongoose.Schema({
   name: {
@@ -10,6 +11,10 @@ const UserSchema = new mongoose.Schema({
     type: String,
     required: true,
     unique: true,
+  },
+  password: {
+    type: String,
+    required: true,
   },
   googleId: {
     type: String,
@@ -30,6 +35,21 @@ const UserSchema = new mongoose.Schema({
     type: Date,
     default: Date.now,
   },
+});
+
+// Hash password before saving
+UserSchema.pre("save", async function (next) {
+  if (!this.isModified("password")) {
+    return next();
+  }
+
+  try {
+    const salt = await bcrypt.genSalt(10);
+    this.password = await bcrypt.hash(this.password, salt);
+    next();
+  } catch (err) {
+    next(err);
+  }
 });
 
 module.exports = mongoose.model("User", UserSchema);

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -183,8 +183,10 @@ router.post("/login", async (req, res) => {
       return res.status(400).json({ message: "Invalid credentials" });
     }
 
-    // For development purposes, allow simple password login
-    // In production, you should verify the password with bcrypt.compare
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      return res.status(400).json({ message: "Invalid credentials" });
+    }
 
     // Generate token
     const payload = {


### PR DESCRIPTION
## Summary
- hash user passwords in the User model
- validate passwords in the login endpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846ea81c3cc83249fa78f7c8dbd3c61