### PR TITLE
Enable tap selection for transaction cards

### DIFF
--- a/client/src/components/Admin/TransactionManagement.js
+++ b/client/src/components/Admin/TransactionManagement.js
@@ -137,13 +137,6 @@ const TransactionManagement = () => {
     });
   };
 
-  const handleSelectAll = () => {
-    if (selectedTransactions.size === transactions.length) {
-      setSelectedTransactions(new Set());
-    } else {
-      setSelectedTransactions(new Set(transactions.map(t => t._id)));
-    }
-  };
 
   const handleBulkDelete = async () => {
     if (window.confirm(`Are you sure you want to delete ${selectedTransactions.size} transaction(s)?`)) {
@@ -197,7 +190,8 @@ const TransactionManagement = () => {
     }
   };
 
-  const isCheckboxDisabled = (transactionId) => {
+  // Disable selection of other transactions when one is already selected
+  const isSelectionLocked = (transactionId) => {
     return selectedTransactions.size === 1 && !selectedTransactions.has(transactionId);
   };
 
@@ -399,14 +393,6 @@ const TransactionManagement = () => {
               <table className={`${styles['responsive-table']} table`}>
                 <thead>
                   <tr>
-                    <th>
-                      <input
-                        type="checkbox"
-                        checked={selectedTransactions.size === transactions.length}
-                        onChange={handleSelectAll}
-                        className={styles['select-checkbox']}
-                      />
-                    </th>
                     <th>Date</th>
                     <th>Description</th>
                     <th>Amount</th>
@@ -416,25 +402,21 @@ const TransactionManagement = () => {
                 <tbody>
                   {transactions.length === 0 ? (
                     <tr>
-                      <td colSpan="5" className="text-center">
+                      <td colSpan="4" className="text-center">
                         No transactions found.
                       </td>
                     </tr>
                   ) : (
                     transactions.map((transaction) => (
-                      <tr 
+                      <tr
                         key={transaction._id}
-                        className={selectedTransactions.has(transaction._id) ? styles['selected-row'] : ''}
+                        className={selectedTransactions.has(transaction._id) ? `${styles['selected-row']} ${styles['clickable-row']}` : styles['clickable-row']}
+                        onClick={() => {
+                          if (!isSelectionLocked(transaction._id)) {
+                            handleSelectTransaction(transaction._id);
+                          }
+                        }}
                       >
-                        <td>
-                          <input
-                            type="checkbox"
-                            checked={selectedTransactions.has(transaction._id)}
-                            onChange={() => handleSelectTransaction(transaction._id)}
-                            className={styles['select-checkbox']}
-                            disabled={isCheckboxDisabled(transaction._id)}
-                          />
-                        </td>
                         <td>{formatDate(transaction.date)}</td>
                         <td><span className={styles.ellipsis}>{transaction.description}</span></td>
                         <td>

--- a/client/src/components/Admin/TransactionManagement.module.css
+++ b/client/src/components/Admin/TransactionManagement.module.css
@@ -256,50 +256,42 @@
   }
 }
 
-/* Table column width adjustments */
 .responsive-table th:first-child,
 .responsive-table td:first-child {
-  width: 40px;
-  min-width: 40px;
-  max-width: 40px;
+  width: 100px;
+  min-width: 100px;
   padding: 0.5rem;
-  text-align: center;
+  text-align: left;
 }
 
 .responsive-table th:nth-child(2),
 .responsive-table td:nth-child(2) {
-  width: 100px;
-  min-width: 100px;
-  max-width: 100px;
+  min-width: 200px;
   white-space: nowrap;
 }
 
-.responsive-table th:nth-child(3),
-.responsive-table td:nth-child(3) {
-  min-width: 200px;
-}
 
+.responsive-table th:nth-child(3),
+.responsive-table td:nth-child(3),
 .responsive-table th:nth-child(4),
-.responsive-table td:nth-child(4),
-.responsive-table th:nth-child(5),
-.responsive-table td:nth-child(5) {
+.responsive-table td:nth-child(4) {
   width: 120px;
   min-width: 120px;
   text-align: right;
 }
 
-/* Checkbox styles */
-.select-checkbox {
-  width: 16px;
-  height: 16px;
+
+/* Card/row interaction styles */
+.clickable-row {
   cursor: pointer;
-  accent-color: var(--primary-color);
-  margin: 0;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 /* Selected row styles */
 .selected-row {
   background-color: rgba(var(--primary-rgb), 0.1);
+  border: 2px solid var(--primary-color);
+  box-shadow: 0 0 4px rgba(var(--primary-rgb), 0.25);
 }
 
 /* Bulk actions styles */
@@ -435,10 +427,6 @@
     width: auto;
     min-width: 0;
     max-width: none;
-  }
-  .select-checkbox {
-    width: 16px;
-    height: 16px;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove checkboxes in transaction table
- allow tapping on a card/row to select it
- highlight selected card with border and shadow

## Testing
- `npm install` *(fails: Jest cannot parse ES module axios)*
- `CI=true npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6848506c0e808324b6034289bd3facc7