### PR TITLE
Add Jest transform ignore for axios

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,11 @@
       "react-app/jest"
     ]
   },
+  "jest": {
+    "transformIgnorePatterns": [
+      "/node_modules/(?!axios)/"
+    ]
+  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
## Summary
- allow axios to be transformed by Jest in the client app
- run tests

## Testing
- `npm test -- --watchAll=false` *(fails: TypeError Cannot destructure property 'user'...)*

------
https://chatgpt.com/codex/tasks/task_e_684bc7d0f16883249abb93016e719f43