### PR TITLE
Fix mobile table widths

### DIFF
--- a/client/src/components/Admin/TransactionManagement.module.css
+++ b/client/src/components/Admin/TransactionManagement.module.css
@@ -428,6 +428,17 @@
     min-width: 0;
     max-width: none;
   }
+  .responsive-table th:first-child,
+  .responsive-table td:first-child,
+  .responsive-table th:nth-child(2),
+  .responsive-table td:nth-child(2),
+  .responsive-table th:nth-child(3),
+  .responsive-table td:nth-child(3),
+  .responsive-table th:nth-child(4),
+  .responsive-table td:nth-child(4) {
+    width: auto;
+    min-width: 0;
+  }
 }
 
 /* Card layout for ultra-small screens */


### PR DESCRIPTION
## Summary
- remove column width overrides on small screens so tables shrink properly

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot destructure property 'user' of 'useAuth' as it is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_684bde5217008324b3189e5398d63738